### PR TITLE
Fix for OAuth2 token selection

### DIFF
--- a/Kernel/System/Email/MultiSMTP.pm
+++ b/Kernel/System/Email/MultiSMTP.pm
@@ -125,7 +125,7 @@ sub Send {
                 $Module => \%SMTP,
             );
 
-            my $SMTPObject  = $Kernel::OM->Get($Module);
+            my $SMTPObject  = $Kernel::OM->Create($Module);
 
             if ($SMTPObject->{User} ne $SMTP{User}) {
                 if ( $Self->{Debug} ) {


### PR DESCRIPTION
As mentioned in this issue https://github.com/reneeb/opm-MultiSMTP/issues/17, this addon selects the wrong token to send an email.

The problem is, that the SMTP-Object gets created once and the object manager return the same object for each connection.
The new configuration is discarded this way and the configuration used is always the one that should be used for the first mail.

This fix creates a new object for each connection.

For those, who need a fix right now, you can download a fixed opm [here](https://github.com/mxcOpen/opm-MultiSMTP) until this repository is updated